### PR TITLE
fix the exits abnormal due to trace buffer

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1278,7 +1278,10 @@ class BPF(object):
             task = line[:16].lstrip()
             line = line[17:]
             ts_end = line.find(b":")
-            pid, cpu, flags, ts = line[:ts_end].split()
+            try:
+                pid, cpu, flags, ts = line[:ts_end].split()
+            except Exception as e:
+                continue
             cpu = cpu[1:-1]
             # line[ts_end:] will have ": [sym_or_addr]: msgs"
             # For trace_pipe debug output, the addr typically
@@ -1290,7 +1293,10 @@ class BPF(object):
             line = line[ts_end + 1:]
             sym_end = line.find(b":")
             msg = line[sym_end + 2:]
-            return (task, int(pid), int(cpu), flags, float(ts), msg)
+            try:
+                return (task, int(pid), int(cpu), flags, float(ts), msg)
+            except Exception as e:
+                return ("Unknown", 0, 0, "Unknown", 0.0, "Unknown")
 
     def trace_readline(self, nonblocking=False):
         """trace_readline(nonblocking=False)


### PR DESCRIPTION
Some data may be left in the trace buffer, and the format cannot be
parsed by trace_fields(), which whill cause an abnormality in the
system.

Re-running the program cannot solved, only restart kernel.

Call trace:
      File "/usr/lib/python2.7/site-packages/kwaibcc/__init__.py", line 1273, in trace_fields
        pid, cpu, flags, ts = line[:ts_end].split()
    ValueError: need more than 2 values to unpack

Prevent problems with exception handling.

Signed-off-by: Chen Guanqiao <chen.chenchacha@foxmail.com>